### PR TITLE
Add feature for configuring dataset distribution among the clients

### DIFF
--- a/Server/README.md
+++ b/Server/README.md
@@ -2,9 +2,9 @@
 
 An implementation of a Federated Learning Server
 
-## Set configure file
+## Set config file
 
-The configure file must exist within the working directory the user sets from command line. The user must also add '''--config true''' to tell the Server that the config.json file must be used, otherwise the dataset it is divided evenly among clients.  
+The config file must exist within the working directory the user sets from command line. The user must also add '''--config true''' to tell the Server that the config.json file must be used, otherwise the dataset it is divided evenly among clients.  
 
 ## Build Docker image
 

--- a/Server/README.md
+++ b/Server/README.md
@@ -2,6 +2,10 @@
 
 An implementation of a Federated Learning Server
 
+## Set configure file
+
+The configure file must exist within the working directory the user sets from command line. The user must also add '''--config true''' to tell the Server that the config.json file must be used, otherwise the dataset it is divided evenly among clients.  
+
 ## Build Docker image
 
 Remember to set the working directory (is set to the current directory by default). The working directory should contain the new model and the CIFAR10 dataset
@@ -15,5 +19,7 @@ docker build -t [name] --build-arg WDIR=[path to working directory] --secret id=
 ```
 docker run --network="host" -e PORT=[port] [image name] --fl --port [port] --workdir [path to working directory] --minClients [minimum Clients] --datasetratio [ratio of the dataset] --rounds [rounds]
 ```
+
+ 
 
 

--- a/Server/README.md
+++ b/Server/README.md
@@ -4,7 +4,7 @@ An implementation of a Federated Learning Server
 
 ## Set config file
 
-The config file must exist within the working directory the user sets from command line. The user must also add '''--config true''' to tell the Server that the config.json file must be used, otherwise the dataset it is divided evenly among clients.  
+The config file must exist within the working directory the user sets from command line. The user must also add '--config true' to tell the Server that the config.json file must be used, otherwise the dataset it is divided evenly among clients.  
 
 ## Build Docker image
 

--- a/Server/config.json
+++ b/Server/config.json
@@ -1,0 +1,7 @@
+{
+    "evenLabelDistributionByClient": false,
+    "distributionRatiosByClient": [0.2, 0.3, 0.5],
+    "distributionRatiosByLabels": [[0.5, 0.25, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
+				   [0.25, 0.5, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25],
+				   [0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25]]
+}

--- a/Server/src/main/java/com/bnnthang/fltestbed/Server/App.java
+++ b/Server/src/main/java/com/bnnthang/fltestbed/Server/App.java
@@ -21,6 +21,7 @@ public class App {
     private static final String DEFAULT_MODEL_DIR = "C:/Users/buinn/DoNotTouch/crap/photolabeller";
     private static final String DEFAULT_APK_PATH = "C:\\Users\\buinn\\Repos\\FederatedLearningTestbed\\AndroidClient\\app\\build\\intermediates\\apk\\debug\\app-debug.apk";;
     private static final float DEFAULT_DATASET_RATIO = 1.0F;
+    private static final boolean DEFAULT_USE_CONFIG = false;
 
     public static void main(String[] args) throws Exception {
         _logger.debug("hello world");
@@ -74,6 +75,7 @@ public class App {
         String workDir = DEFAULT_MODEL_DIR;
         String apkPath = DEFAULT_APK_PATH;
         float ratio = DEFAULT_DATASET_RATIO;
+        boolean useConfig = DEFAULT_USE_CONFIG;
         for (int i = 1; i < args.length; i += 2) {
             switch (args[i]) {
                 case "--port":
@@ -94,13 +96,16 @@ public class App {
                 case "--apk":
                     apkPath = args[i + 1];
                     break;
+                case "--config":
+                    useConfig = Boolean.parseBoolean(args[i + 1]);
+                    break;
                 default:
                     throw new UnsupportedOperationException("unsupported argument: " + args[i]);
             }
         }
 
         TrainingConfiguration trainingConfiguration = new TrainingConfiguration(minClients, rounds, 5000, new FedAvg(), ratio);
-        IServerOperations serverOperations = new BaseServerOperations(new Cifar10Repository(workDir));
+        IServerOperations serverOperations = new BaseServerOperations(new Cifar10Repository(workDir, useConfig));
         ServerParameters serverParameters = new ServerParameters(port, trainingConfiguration, serverOperations);
         BaseServer server = new BaseServer(serverParameters);
         server.start();


### PR DESCRIPTION
Two main features added: 

1. You can control how the dataset is divided among clients (label distribution is even in this case)
2. You can also control how the lables are divided among clients

Use the config.json file to adjust however you want. Set "evenLabelDistributionByClient" to true in config.json if you want first option, and to false if you want second. Add "--config true" to use the added features

Keep in mind the ratios for feature 1. must add up to 1.0. For feature 2, the ratios for each label must also add up to 1.0. Otherwise an exception is thrown. Also make sure number of clients matches how many ratios you give.