### PR TITLE
Add feature for dropping clients during the training

### DIFF
--- a/Server/config.json
+++ b/Server/config.json
@@ -1,7 +1,9 @@
 {
-    "evenLabelDistributionByClient": false,
-    "distributionRatiosByClient": [0.2, 0.3, 0.5],
+    "evenLabelDistributionByClient": true,
+    "distributionRatiosByClient": [0.3, 0.3, 0.4],
     "distributionRatiosByLabels": [[0.5, 0.25, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
 				   [0.25, 0.5, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25],
-				   [0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25]]
+				   [0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25]],
+    "useDropping": true,
+    "dropping": [{"round":1,"#clients":1},{"round":2,"#clients":1} ]
 }


### PR DESCRIPTION
User can use the config.json file to decide when they want the clients to be dropped during training and how many.
To use the feature, user must :
1 - set "useDropping" to true in config.json. 
2- They can then add a list of objects as shown in config.json to decide when and how many they want dropped. 
Keep in mind which clients to be dropped cannot be decided by user. Also, if number of clients to  be dropped is more than available clients, Server does not give error but rather ignores the request and continues traininng on one client. 