### PR TITLE
Add health dataset to the FL (incomplete)

### DIFF
--- a/Client/src/main/java/com/bnnthang/fltestbed/Client/App.java
+++ b/Client/src/main/java/com/bnnthang/fltestbed/Client/App.java
@@ -22,6 +22,7 @@ public class App {
     private static final String DEFAULT_WORK_DIR = "C:/Users/buinn/DoNotTouch/crap/testbed";
 
     private static final int DEFAULT_NUM_CLIENTS = 1;
+    private static final boolean DEFAULT_USE_HEALTH_DATASET = false;
 
     public static void main(String[] args) throws IOException, InterruptedException {
         switch (args[0]) {
@@ -62,7 +63,8 @@ public class App {
 
             String pathToModel = clientDir + "/model.zip";
             String pathToDataset = clientDir + "/dataset";
-            IClientLocalRepository localRepository = new LocalRepositoryImpl(pathToModel, pathToDataset);
+            Boolean useHealthDataset = parameters.getUseHealthDataset();
+            IClientLocalRepository localRepository = new LocalRepositoryImpl(pathToModel, pathToDataset, useHealthDataset);
             IClientOperations clientOperations = new BaseClientOperations(localRepository);
             BaseClient client = new BaseClient(parameters.getServerHost(), parameters.getServerPort(), 5000, clientOperations);
             client.start();
@@ -83,6 +85,7 @@ public class App {
         int port = DEFAULT_SERVER_PORT;
         String workDir = DEFAULT_WORK_DIR;
         int numClients = DEFAULT_NUM_CLIENTS;
+        boolean useHealthDataset = DEFAULT_USE_HEALTH_DATASET;
         for (int i = 1; i < args.length; i += 2) {
             switch (args[i]) {
                 case "--host":
@@ -97,10 +100,13 @@ public class App {
                 case "--nclients":
                     numClients = Integer.parseInt(args[i + 1]);
                     break;
+                case "--healthdataset":
+                    useHealthDataset = Boolean.parseBoolean(args[i + 1]);
+                    break;
                 default:
                     throw new UnsupportedOperationException("unsupported parameter: " + args[i]);
             }
         }
-        return new ClientParameters(host, port, workDir, numClients);
+        return new ClientParameters(host, port, workDir, numClients, useHealthDataset);
     }
 }

--- a/Client/src/main/java/com/bnnthang/fltestbed/Client/LocalRepositoryImpl.java
+++ b/Client/src/main/java/com/bnnthang/fltestbed/Client/LocalRepositoryImpl.java
@@ -23,10 +23,14 @@ public class LocalRepositoryImpl implements IClientLocalRepository {
 
     @NonNull
     private final String pathToDataset;
+    @NonNull
+    public final boolean useHealthDataset;
 
-    public LocalRepositoryImpl(@NonNull String _pathToModel, @NonNull String _pathToDataset) {
+    public LocalRepositoryImpl(@NonNull String _pathToModel, @NonNull String _pathToDataset,
+                               @NonNull boolean _useHealthDataset) {
         pathToModel = _pathToModel;
         pathToDataset = _pathToDataset;
+        useHealthDataset = _useHealthDataset;
     }
 
     @Override
@@ -116,4 +120,7 @@ public class LocalRepositoryImpl implements IClientLocalRepository {
     public String getModelPath() {
         return pathToModel;
     }
+
+    @Override
+    public Boolean getUseHealthDataset(){return useHealthDataset;}
 }

--- a/Client/src/main/java/com/bnnthang/fltestbed/Client/ML.java
+++ b/Client/src/main/java/com/bnnthang/fltestbed/Client/ML.java
@@ -1,6 +1,6 @@
 package com.bnnthang.fltestbed.Client;
 
-import com.bnnthang.fltestbed.commonutils.models.BaseCifar10Loader;
+import com.bnnthang.fltestbed.commonutils.models.BaseDatasetLoader;
 import com.bnnthang.fltestbed.commonutils.models.MemoryListener;
 import com.bnnthang.fltestbed.commonutils.models.NewCifar10DSIterator;
 import org.datavec.image.loader.CifarLoader;
@@ -86,8 +86,8 @@ public class ML {
 
     public static void trainAndEval() throws IOException {
         String path = "C:\\Users\\buinn\\DoNotTouch\\crap\\testbed\\dirclient0";
-        LocalRepositoryImpl repo = new LocalRepositoryImpl(path + "/model.zip", path + "/dataset");
-        BaseCifar10Loader loader = new BaseCifar10Loader(repo);
+        LocalRepositoryImpl repo = new LocalRepositoryImpl(path + "/model.zip", path + "/dataset", false);
+        BaseDatasetLoader loader = new BaseDatasetLoader(repo);
 //        BaseCifar10DataSetIterator mycifar = new BaseCifar10DataSetIterator(loader, 33, 1);
         NewCifar10DSIterator newCifar = new NewCifar10DSIterator(loader, 23);
 

--- a/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/clients/BaseClientOperations.java
+++ b/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/clients/BaseClientOperations.java
@@ -14,7 +14,7 @@ import java.net.Socket;
 public class BaseClientOperations implements IClientOperations {
     private static final Logger _logger = LoggerFactory.getLogger(BaseClientOperations.class);
 
-    protected static final int BATCH_SIZE = 12;
+    protected static final int BATCH_SIZE = 128;
 
     protected static final int EPOCHS = 2;
 

--- a/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/clients/IClientLocalRepository.java
+++ b/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/clients/IClientLocalRepository.java
@@ -19,4 +19,5 @@ public interface IClientLocalRepository {
     InputStream getDatasetInputStream() throws IOException;
     File getModelFile() throws IOException;
     String getModelPath();
+    Boolean getUseHealthDataset();
 }

--- a/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/models/BaseDatasetLoader.java
+++ b/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/models/BaseDatasetLoader.java
@@ -9,12 +9,17 @@ import org.nd4j.linalg.util.FeatureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 
-public class BaseCifar10Loader implements ICifar10Loader {
+public class BaseDatasetLoader implements IDatasetLoader {
     /**
      * Label size (in bytes).
      */
@@ -23,27 +28,27 @@ public class BaseCifar10Loader implements ICifar10Loader {
     /**
      * Image height (in pixels).
      */
-    protected final static int IMAGE_HEIGHT = 32;
+    protected static int IMAGE_HEIGHT = 32;
 
     /**
      * Image width (in pixels).
      */
-    protected final static int IMAGE_WIDTH = 32;
+    protected static int IMAGE_WIDTH = 32;
 
     /**
      * Image channels.
      */
-    protected final static int IMAGE_CHANNELS = 3;
+    protected static int IMAGE_CHANNELS = 3;
 
     /**
      * Image size (in bytes).
      */
-    protected final static int IMAGE_SIZE = IMAGE_WIDTH * IMAGE_HEIGHT * IMAGE_CHANNELS;
+    protected static int IMAGE_SIZE = IMAGE_WIDTH * IMAGE_HEIGHT * IMAGE_CHANNELS;
 
     /**
      * Row size (in bytes).
      */
-    protected final static int ROW_SIZE = LABEL_SIZE + IMAGE_SIZE;
+    protected static int ROW_SIZE = LABEL_SIZE + IMAGE_SIZE;
 
     /**
      * Local file repository.
@@ -53,7 +58,7 @@ public class BaseCifar10Loader implements ICifar10Loader {
     /**
      * Logger.
      */
-    private static final Logger _logger = LoggerFactory.getLogger(BaseCifar10Loader.class);
+    private static final Logger _logger = LoggerFactory.getLogger(BaseDatasetLoader.class);
 
     private long rowCount = -1;
 
@@ -61,8 +66,16 @@ public class BaseCifar10Loader implements ICifar10Loader {
      * Instantiate <code>MyCifar10Loader</code>
      * @param _localRepository an instance of <code>ILocalRepository</code>
      */
-    public BaseCifar10Loader(IClientLocalRepository _localRepository) {
+    public BaseDatasetLoader(IClientLocalRepository _localRepository) {
+
         localRepository = _localRepository;
+        // if health dataset, change configuration
+        if (localRepository.getUseHealthDataset()){
+            IMAGE_WIDTH = 180;
+            IMAGE_HEIGHT = 180;
+            IMAGE_SIZE = IMAGE_WIDTH * IMAGE_HEIGHT * IMAGE_CHANNELS;
+            ROW_SIZE = LABEL_SIZE + IMAGE_SIZE;
+        }
     }
 
     /**
@@ -152,7 +165,12 @@ public class BaseCifar10Loader implements ICifar10Loader {
             }
         }
 
+        ImageIO.write(bufferedImage, "jpg", new File("/home/temoor/Desktop/FL/image.jpg"));
+
+
         Java2DNativeImageLoader imageLoader = new Java2DNativeImageLoader(IMAGE_HEIGHT, IMAGE_WIDTH, IMAGE_CHANNELS);
+
+
 
         return imageLoader.asMatrix(bufferedImage, true);
     }

--- a/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/models/ClientParameters.java
+++ b/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/models/ClientParameters.java
@@ -16,4 +16,7 @@ public class ClientParameters {
 
     @NonNull
     private Integer numClients;
+
+    @NonNull
+    private Boolean useHealthDataset;
 }

--- a/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/models/IDatasetLoader.java
+++ b/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/models/IDatasetLoader.java
@@ -6,7 +6,7 @@ import org.nd4j.linalg.dataset.DataSet;
 import java.io.IOException;
 import java.util.Map;
 
-public interface ICifar10Loader {
+public interface IDatasetLoader {
     long count() throws IOException;
     Map<Integer, Integer> getDataDistribution() throws IOException;
     DataSet createDataSet(int batchSize, int fromIndex) throws IOException;

--- a/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/models/NewChestXrayDSIterator.java
+++ b/CommonUtils/src/main/java/com/bnnthang/fltestbed/commonutils/models/NewChestXrayDSIterator.java
@@ -11,19 +11,19 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class NewCifar10DSIterator implements DataSetIterator {
+public class NewChestXrayDSIterator implements DataSetIterator {
     private final IDatasetLoader _loader;
 
     private int currentIndex = 0;
 
     private final int _batchSize;
 
-    private Logger _logger = LoggerFactory.getLogger(NewCifar10DSIterator.class.getName());
+    private Logger _logger = LoggerFactory.getLogger(NewChestXrayDSIterator.class.getName());
 
-    public NewCifar10DSIterator(IDatasetLoader loader, int batchSize) {
+    public NewChestXrayDSIterator(IDatasetLoader loader, int batchSize) {
         _loader = loader;
         _batchSize = batchSize;
-        _logger.info("init new cifar dsiterator");
+        _logger.info("init new chest xray dsiterator");
     }
 
     @Override
@@ -44,7 +44,7 @@ public class NewCifar10DSIterator implements DataSetIterator {
 
     @Override
     public int totalOutcomes() {
-        return 10;
+        return 2;
     }
 
     @Override
@@ -80,16 +80,8 @@ public class NewCifar10DSIterator implements DataSetIterator {
     @Override
     public List<String> getLabels() {
         return new ArrayList<>(Arrays.asList(
-                "airplane",
-                "automobile",
-                "bird",
-                "cat",
-                "deer",
-                "dog",
-                "frog",
-                "horse",
-                "ship",
-                "truck"
+                "NORMAL",
+                "PNEUMONIA"
         ));
     }
 

--- a/Server/src/main/java/com/bnnthang/fltestbed/Server/App.java
+++ b/Server/src/main/java/com/bnnthang/fltestbed/Server/App.java
@@ -56,7 +56,7 @@ public class App {
 
         TrainingConfiguration trainingConfiguration = new TrainingConfiguration(args.numClients, args.rounds, 5000, new FedAvg(), args.datasetRatio, args.useConfig);
         trainingConfiguration.setJsonObject(jsonObject);
-        IServerOperations serverOperations = new BaseServerOperations(new Cifar10Repository(args.workDir, args.useConfig, jsonObject));
+        IServerOperations serverOperations = new BaseServerOperations(new Cifar10Repository(args.workDir, args.useConfig, jsonObject, args.useHealthDataset));
         ServerParameters serverParameters = new ServerParameters(args.port, trainingConfiguration, serverOperations);
         BaseServer server = new BaseServer(serverParameters);
         server.start();

--- a/Server/src/main/java/com/bnnthang/fltestbed/Server/AppArgs.java
+++ b/Server/src/main/java/com/bnnthang/fltestbed/Server/AppArgs.java
@@ -24,6 +24,9 @@ public class AppArgs {
     @Parameter(names = "--config", description = "Set to true if config.json file is to be used, otherwise data will be divided evenly among clients")
     public Boolean useConfig = false;
 
+    @Parameter(names = "--healthdataset", description = "Set to true if the health dataset is to be used, otherwise cifar-10 dataset will be used")
+    public Boolean useHealthDataset = false;
+
     @Parameter(names = "--fl")
     public Boolean fl = false;
 


### PR DESCRIPTION
Brief explanation of changes made:
- Added new argument to Server and Client side called useHealthDataset, to be set as true if the health dataset is to be used
- Xray model file is called xraymodel.zip, must also be in the workdir
- The dataset is to be stored in the workdir under the name train_batch.bin and test_batch
- Xray dataset exists in the form of a binary file, the file was converted from an image dataset using a script
- The dataset is originally not in binary form and must be converted using the script
- Changed BaseCifar10Loader and ICifar10Loader to BaseDatasetLoader and IDatasetLoader respectively
- Overall, functions used to load the cifar 10 dataset are reused to load the xray dataset, hence the imageSize, imageHeight etc. have been modularized
- Added a new class called NewChestXrayDSIterator, similar to NewCifar10DSIterator